### PR TITLE
Improve GNSW prohibited donor checkbox rendering

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Package: au.org.greens.foreigndonors
-Copyright (C) 2019, FIXME <FIXME>
+Copyright (C) 2021, Australian Greens
 Licensed under the GNU Affero Public License 3.0 (below).
 
 -------------------------------------------------------------------------------

--- a/foreigndonors.php
+++ b/foreigndonors.php
@@ -215,16 +215,18 @@ function foreigndonors_civicrm_buildForm($formName, &$form) {
         ->execute();
     }
 
+    $isNSW = substr($finType[0]['financial_type_id:label'], 0, 3) === 'NSW';
+
     // Add the checkbox to the public form
     // Have to use different language for Queensland
     // Inject a prohibited donor checkbox for NSW
     // if the domain is NSW or the fin type starts with 'NSW'
-    if ($domainId == 7) {
+    if ($domainId == 7 && !$isNSW) {
       $label = "I am an Australian Citizen or Permanent Resident, and not a QLD prohibited donor";
       $form->add('Checkbox', 'foreigndonor', ts('I am an Australian Citizen or Permanent Resident, and not a QLD prohibited donor'));
       $form->addRule('foreigndonor', ts('You must affirm you are not a prohibited donor as per State and Federal legislation'), 'required', NULL, 'client');
     }
-    elseif ($domainId == 8 || substr($finType[0]['financial_type_id:label'], 0, 3) === 'NSW') {
+    elseif ($domainId == 8 || $isNSW ) {
       $form->assign('addProhibitedDonor', TRUE);
       $label = "I am an Australian Citizen or Permanent Resident and am not a foreign donor";
       $form->add('Checkbox', 'foreigndonor', ts('I am an Australian Citizen or Permanent Resident and am not a foreign donor'));

--- a/info.xml
+++ b/info.xml
@@ -15,8 +15,8 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-04-27</releaseDate>
-  <version>0.10.0</version>
-  <develStage>beta</develStage>
+  <version>1.0.0</version>
+  <develStage>stable</develStage>
   <compatibility>
     <ver>5.19</ver>
   </compatibility>

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://greens.org.au</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-12-27</releaseDate>
-  <version>0.9.0</version>
+  <releaseDate>2021-04-27</releaseDate>
+  <version>0.10.0</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.19</ver>

--- a/templates/foreigndonors.tpl
+++ b/templates/foreigndonors.tpl
@@ -20,7 +20,8 @@
   </div>
   <div class="content">{$form.foreigndonor.html}</div>
 </div>
-{if $domainId eq '8'}
+{* inject prohibited donor checkbox for NSW domain and NSW fin type forms *}
+{if $addProhibitedDonor}
   <div class="crm-section prohibiteddonor-section">
     <div class="label">
       <label for="prohibiteddonor">I am not a prohibited donor <i id="prohibiteddonor-help" class="fa fa-question-circle" aria-hidden="true"></i></label>


### PR DESCRIPTION
This change forces the inclusion of the Prohibited Donor checkbox on any contribution or event registration page if the associated financial type starts with the letters 'NSW'. This adds to, rather than replaces, the existing functionality which is based on a domain check. I've also added/refined some of the inline comments.

The driver for this is to reduce the address the edge case where someone completes a form while in a non-NSW domain.

This has been tested in dev successfully. It's possible to load the GNSW main donation page via the AG page and

1. see the Prohibited Donor checkbox on step 2
2. complete a transaction and see the corresponding custom field in the contrib record properly set
