### PR TITLE
Ensure unpaid events do not include foreign donor checkboxes as no fi…

### DIFF
--- a/foreigndonors.php
+++ b/foreigndonors.php
@@ -192,6 +192,9 @@ function foreigndonors_civicrm_buildForm($formName, &$form) {
     if ($formName == 'CRM_Event_Form_Registration_Register' && !_foreigndonors_checkEnabled($formId, 'event_fee')) {
       return;
     }
+    if ($formName == 'CRM_Event_Form_Registration_Register' && !$form->_values['event']['is_monetary']) {
+      return;
+    }
 
     $form->assign('domainId', $domainId);
     $form->assign('foreignPageId', $formId);


### PR DESCRIPTION
This PR ensures CiviCRM events that are _unpaid_ do not show foreign donor checkboxes. It doesn't make sense to enforce foreign donor compliance when there's no financial transaction involved.

I tested this locally using my dev instance of CiviCRM. We need to test the value of the `is_monetary` field in the event.